### PR TITLE
feat(redirects): Add CloudOps->Aptum 301 for 7-things-2018 blog post

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,18 @@ HUGO_VERSION = "0.74.3"
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
 
+# --- CloudOps -> Aptum 301 redirects (cloudops.com retirement) ---
+# PILOT: one blog post, per redirect map "Pattern rules" (/blog/* -> /blog/).
+# force = true is required: Hugo still builds this page into public/, so without
+# force Netlify serves the file and the redirect never fires.
+# ?ref=cloudops is the PROVISIONAL banner signal for aptum.com; confirm the
+# parameter name with Double Up before the full rollout.
+[[redirects]]
+  from = "/blog/7-things-cloudops-is-betting-on-in-2018/"
+  to = "https://aptum.com/blog/?ref=cloudops"
+  status = 301
+  force = true
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
First pilot of the cloudops.com retirement redirects. 301 the long-tail blog post /blog/7-things-cloudops-is-betting-on-in-2018/ to https://aptum.com/blog/ per the redirect map Pattern rules (/blog/* -> /blog/).

force = true is required because Hugo still builds this page into public/; without it Netlify serves the file and the redirect never fires.

?ref=cloudops is the provisional banner signal for aptum.com and must be confirmed with Double Up before the full rollout.

### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Explain in a sentence or two what the problem is and what the expected behaviour is.

#### Solution
Explain in a sentence or two how it was solved and what the root cause was.

#### Test cases
- This should be the list of scenarios tested (e.g. tested with root account, tested with normal user)
- e.g. API tests included
- e.g. Tested with user access levels
- e.g. Manually API tested

#### UI changes
Add screenshot here if necessary
OR
No changes

<!-- Uncomment if PRs from other repos related to the same story 
#### Related PRs
- PR #
-->
